### PR TITLE
Prototype for optimization policy feature

### DIFF
--- a/src/ui/src/common/extension_command.ts
+++ b/src/ui/src/common/extension_command.ts
@@ -26,6 +26,15 @@ export declare interface ExtensionCommand {
   extensionId: string;
 }
 
+/** A response received from the extension. */
+export interface ExtensionResponse {
+  error?: string;
+  metadata?: {
+    optimizationPolicies?: string[],
+    [k: string]: any
+  };
+}
+
 /** Adapter's "convert" command. */
 export declare interface AdapterConvertCommand extends ExtensionCommand {
   cmdId: 'convert';
@@ -37,10 +46,9 @@ export declare interface AdapterConvertCommand extends ExtensionCommand {
 }
 
 /** Adapter's "convert" command response. */
-export declare interface AdapterConvertResponse {
+export declare interface AdapterConvertResponse extends ExtensionResponse {
   graphs?: Graph[];
   graphCollections?: GraphCollection[];
-  error?: string;
 }
 
 /** Adapter's "override" command. */
@@ -55,10 +63,9 @@ export declare interface AdapterOverrideCommand extends ExtensionCommand {
 }
 
 /** Adapter's "override" command response. */
-export declare interface AdapterOverrideResponse {
+export declare interface AdapterOverrideResponse extends ExtensionResponse {
   success: boolean;
   graphs?: Graph[];
-  error?: string;
 }
 
 /** Adapter's "execute" command. */
@@ -70,6 +77,5 @@ export declare interface AdapterExecuteCommand extends ExtensionCommand {
 }
 
 /** Adapter's "execute" command response. */
-export declare interface AdapterExecuteResponse extends ExecutionCommand {
-  error?: string;
+export declare interface AdapterExecuteResponse extends ExtensionResponse, ExecutionCommand {
 }

--- a/src/ui/src/common/extension_command.ts
+++ b/src/ui/src/common/extension_command.ts
@@ -17,7 +17,6 @@
  */
 
 import {Graph, GraphCollection,} from '../components/visualizer/common/input_graph';
-import type { NodeDataProviderData } from '../components/visualizer/common/types.js';
 import type { ChangesPerNode, ExecutionCommand } from './model_loader_service_interface';
 
 /** A command sent to extension. */
@@ -29,10 +28,6 @@ export declare interface ExtensionCommand {
 /** A response received from the extension. */
 export interface ExtensionResponse {
   error?: string;
-  metadata?: {
-    optimizationPolicies?: string[],
-    [k: string]: any
-  };
 }
 
 /** Adapter's "convert" command. */

--- a/src/ui/src/common/extension_command.ts
+++ b/src/ui/src/common/extension_command.ts
@@ -72,7 +72,4 @@ export declare interface AdapterExecuteCommand extends ExtensionCommand {
 /** Adapter's "execute" command response. */
 export declare interface AdapterExecuteResponse extends ExecutionCommand {
   error?: string;
-  log_file: string;
-  stdout: string;
-  perf_data?: NodeDataProviderData
 }

--- a/src/ui/src/common/model_loader_service_interface.ts
+++ b/src/ui/src/common/model_loader_service_interface.ts
@@ -41,6 +41,8 @@ export interface ModelLoaderServiceInterface {
   get loadedGraphCollections(): WritableSignal<GraphCollection[] | undefined>;
   get models(): WritableSignal<ModelItem[]>;
   get changesToUpload(): WritableSignal<ChangesPerGraphAndNode>;
+  get optimizationPolicies(): WritableSignal<string[]>;
+  get selectedOptimizationPolicy(): WritableSignal<string>;
   get graphErrors(): WritableSignal<string[] | undefined>;
   get hasChangesToUpload(): boolean;
 }

--- a/src/ui/src/common/model_loader_service_interface.ts
+++ b/src/ui/src/common/model_loader_service_interface.ts
@@ -41,7 +41,7 @@ export interface ModelLoaderServiceInterface {
   get loadedGraphCollections(): WritableSignal<GraphCollection[] | undefined>;
   get models(): WritableSignal<ModelItem[]>;
   get changesToUpload(): WritableSignal<ChangesPerGraphAndNode>;
-  get optimizationPolicies(): string[];
+  getOptimizationPolicies(extensionId: string): string[];
   get selectedOptimizationPolicy(): WritableSignal<string>;
   get graphErrors(): WritableSignal<string[] | undefined>;
   get hasChangesToUpload(): boolean;

--- a/src/ui/src/common/model_loader_service_interface.ts
+++ b/src/ui/src/common/model_loader_service_interface.ts
@@ -41,7 +41,7 @@ export interface ModelLoaderServiceInterface {
   get loadedGraphCollections(): WritableSignal<GraphCollection[] | undefined>;
   get models(): WritableSignal<ModelItem[]>;
   get changesToUpload(): WritableSignal<ChangesPerGraphAndNode>;
-  get optimizationPolicies(): WritableSignal<string[]>;
+  get optimizationPolicies(): string[];
   get selectedOptimizationPolicy(): WritableSignal<string>;
   get graphErrors(): WritableSignal<string[] | undefined>;
   get hasChangesToUpload(): boolean;

--- a/src/ui/src/common/types.ts
+++ b/src/ui/src/common/types.ts
@@ -52,6 +52,11 @@ export declare interface ExtensionBase {
   type: ExtensionType;
 }
 
+export interface ExtensionSettings {
+  optimizationPolicies?: string[],
+  [k: string]: any
+};
+
 /** Metadata of an adapter extension. */
 export declare interface AdapterExtension extends ExtensionBase {
   type: ExtensionType.ADAPTER;
@@ -63,6 +68,7 @@ export declare interface AdapterExtension extends ExtensionBase {
 
   // Used internally to match http/https urls.
   matchHttpUrl?: boolean;
+  settings?: ExtensionSettings
 }
 
 /** Union type for extension. */

--- a/src/ui/src/components/visualizer/graph_selector.ng.html
+++ b/src/ui/src/components/visualizer/graph_selector.ng.html
@@ -36,22 +36,41 @@ limitations under the License.
     </div>
   </div>
 
-  <div class="mat-icon-container" matTooltip="Download processed graphs json"
-      (click)="handleClickDownloadGraphJson()">
-    <mat-icon>download</mat-icon>
+  <div class="mat-icon-container">
+      <button mat-icon-button matTooltip="Download processed graphs json" (click)="handleClickDownloadGraphJson()">
+        <mat-icon>download</mat-icon>
+      </button>
   </div>
 
   @if (hasCurModel && hasChangesToUpload) {
-    <div class="mat-icon-container" matTooltip="Upload processed graphs json to server"
-        (click)="handleClickUploadGraph()">
-      <mat-icon>upload</mat-icon>
+    <div class="mat-icon-container">
+      <button mat-icon-button matTooltip="Upload processed graphs json to server" (click)="handleClickUploadGraph()">
+        <mat-icon>upload</mat-icon>
+      </button>
     </div>
   }
 
   @if (hasCurModel && !hasChangesToUpload && !graphHasErrors) {
-    <div class="mat-icon-container" matTooltip="Execute graph"
-        (click)="handleClickExecuteGraph()">
-      <mat-icon>play_arrow</mat-icon>
+    <div class="mat-icon-container">
+        <mat-button-toggle-group hideSingleSelectionIndicator="true">
+          <mat-button-toggle matTooltip="Execute graph" (click)="handleClickExecuteGraph()">
+            @if (optimizationPolicies.length > 1) {
+              ({{selectedOptimizationPolicy}})
+            }
+            <mat-icon>play_arrow</mat-icon>
+          </mat-button-toggle>
+          @if (optimizationPolicies.length > 1) {
+            <mat-button-toggle [matMenuTriggerFor]="optimizationPolicyMenu">
+              <mat-icon>arrow_drop_down</mat-icon>
+            </mat-button-toggle>
+          }
+        </mat-button-toggle-group>
+
+        <mat-menu #optimizationPolicyMenu="matMenu">
+          @for (optimizationPolicy of optimizationPolicies; track $index) {
+            <button mat-menu-item (click)="handleClickSelectOptimizationPolicy(optimizationPolicy)">{{optimizationPolicy}}</button>
+          }
+        </mat-menu>
     </div>
   }
 

--- a/src/ui/src/components/visualizer/graph_selector.ts
+++ b/src/ui/src/components/visualizer/graph_selector.ts
@@ -49,6 +49,9 @@ import { ModelItemStatus } from '../../common/types.js';
 import { MatDialogModule, MatDialog } from '@angular/material/dialog';
 import { GraphErrorsDialog } from '../graph_error_dialog/graph_error_dialog.js';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatButtonModule } from '@angular/material/button';
 
 /** A graph collection in the dropdown menu. */
 export interface GraphCollectionItem {
@@ -78,12 +81,15 @@ const LABEL_WIDTHS: {[label: string]: number} = {};
   selector: 'graph-selector',
   imports: [
     CommonModule,
+    MatButtonModule,
+    MatButtonToggleModule,
+    MatDialogModule,
     MatFormFieldModule,
     MatIconModule,
+    MatMenuModule,
     MatSelectModule,
     MatTooltipModule,
     ReactiveFormsModule,
-    MatDialogModule
   ],
   templateUrl: './graph_selector.ng.html',
   styleUrls: ['./graph_selector.scss'],
@@ -405,6 +411,10 @@ export class GraphSelector {
       `${this.selectedGraphCollectionLabel}.json`,
       this.selectedCollection,
     );
+  }
+
+  handleClickSelectOptimizationPolicy(optimizationPolicy: string) {
+    this.modelLoaderService.selectedOptimizationPolicy.update(() => optimizationPolicy);
   }
 
   getGraphLabel(graph: Graph): string {

--- a/src/ui/src/components/visualizer/graph_selector.ts
+++ b/src/ui/src/components/visualizer/graph_selector.ts
@@ -435,13 +435,12 @@ export class GraphSelector {
     return this.appService.config()?.enableExportToResource === true;
   }
 
-  private getCurrentExtensionId() {
-    const curPane = this.appService.getSelectedPane();
-    const curCollectionLabel = curPane?.modelGraph?.collectionLabel;
-    const models = this.modelLoaderService.models();
-    const curModel = models.find(({ label }) => label === curCollectionLabel);
+  get selectedOptimizationPolicy(): string {
+    return this.modelLoaderService.selectedOptimizationPolicy();
+  }
 
-    return curModel?.selectedAdapter?.id ?? '';
+  get optimizationPolicies(): string[] {
+    return this.modelLoaderService.optimizationPolicies();
   }
 
   private getLabelWidth(label: string, fontSize = 12, bold = false): number {

--- a/src/ui/src/components/visualizer/graph_selector.ts
+++ b/src/ui/src/components/visualizer/graph_selector.ts
@@ -446,11 +446,11 @@ export class GraphSelector {
   }
 
   get selectedOptimizationPolicy(): string {
-    return this.modelLoaderService.selectedOptimizationPolicy();
+    return this.modelLoaderService.selectedOptimizationPolicy() || (this.modelLoaderService.optimizationPolicies[0] ?? 'Default');
   }
 
   get optimizationPolicies(): string[] {
-    return this.modelLoaderService.optimizationPolicies();
+    return this.modelLoaderService.optimizationPolicies;
   }
 
   private getLabelWidth(label: string, fontSize = 12, bold = false): number {

--- a/src/ui/src/components/visualizer/graph_selector.ts
+++ b/src/ui/src/components/visualizer/graph_selector.ts
@@ -446,11 +446,13 @@ export class GraphSelector {
   }
 
   get selectedOptimizationPolicy(): string {
-    return this.modelLoaderService.selectedOptimizationPolicy() || (this.modelLoaderService.optimizationPolicies[0] ?? 'Default');
+    const curExtensionId = this.getCurrentGraphInformation().models[0].selectedAdapter?.id ?? '';
+    return this.modelLoaderService.selectedOptimizationPolicy() || (this.modelLoaderService.getOptimizationPolicies(curExtensionId)[0] ?? 'Default');
   }
 
   get optimizationPolicies(): string[] {
-    return this.modelLoaderService.optimizationPolicies;
+    const curExtensionId = this.getCurrentGraphInformation().models[0].selectedAdapter?.id ?? '';
+    return this.modelLoaderService.getOptimizationPolicies(curExtensionId);
   }
 
   private getLabelWidth(label: string, fontSize = 12, bold = false): number {

--- a/src/ui/src/services/extension_service.ts
+++ b/src/ui/src/services/extension_service.ts
@@ -18,8 +18,8 @@
 
 import {Injectable, signal} from '@angular/core';
 
-import {ExtensionCommand, type AdapterExecuteResponse, type AdapterOverrideResponse} from '../common/extension_command';
-import {Extension} from '../common/types';
+import {ExtensionCommand, type AdapterExecuteResponse, type AdapterOverrideResponse } from '../common/extension_command';
+import {Extension, type ExtensionSettings} from '../common/types';
 import {INTERNAL_COLAB} from '../common/utils';
 
 const EXTERNAL_GET_EXTENSIONS_API_PATH = '/api/v1/get_extensions';
@@ -35,6 +35,8 @@ export class ExtensionService {
   readonly internalColab = INTERNAL_COLAB;
 
   extensions: Extension[] = [];
+
+  extensionSettings = new Map<string, ExtensionSettings>();
 
   constructor() {
     this.loadExtensions();
@@ -155,11 +157,18 @@ export class ExtensionService {
     }
   }
 
+  private processExtensionSettings(extensions: Extension[]) {
+    extensions.forEach(({ id, settings }) => {
+      this.extensionSettings.set(id, settings ?? {});
+    });
+  }
+
   private async loadExtensions() {
     // Talk to BE to get registered extensions.
     let exts: Extension[] = [];
 
     exts = await this.getExtensionsForExternal();
+    this.processExtensionSettings(exts);
     this.extensions = exts;
     this.loading.set(false);
   }

--- a/src/ui/src/services/extension_service.ts
+++ b/src/ui/src/services/extension_service.ts
@@ -142,7 +142,10 @@ export class ExtensionService {
                 ...processAttribute(key, value)
               }))
             }))
-          }))
+          })),
+          metadata: {
+            optimizationPolicies: ['Foo', 'Bar', 'Baz', 'Quux']
+          }
         };
       }
 

--- a/src/ui/src/services/extension_service.ts
+++ b/src/ui/src/services/extension_service.ts
@@ -145,9 +145,6 @@ export class ExtensionService {
               }))
             }))
           })),
-          metadata: {
-            optimizationPolicies: ['Foo', 'Bar', 'Baz', 'Quux']
-          }
         };
       }
 
@@ -183,6 +180,17 @@ export class ExtensionService {
         return [];
       }
       const json = await resp.json() as Extension[];
+
+      // TODO: revert mock API changes!
+      if (localStorage.getItem('mock-api') === 'true') {
+        json.forEach((ext) => {
+          if (ext.id === 'tt_adapter') {
+            ext.settings = {
+              optimizationPolicies: ['Foo', 'Bar', 'Baz', 'Quux']
+            };
+          }
+        });
+      }
 
       return json;
     } catch (e) {

--- a/src/ui/src/services/model_loader_service.ts
+++ b/src/ui/src/services/model_loader_service.ts
@@ -82,12 +82,12 @@ export class ModelLoaderService implements ModelLoaderServiceInterface {
     readonly extensionService: ExtensionService,
   ) {}
 
-  get optimizationPolicies(): string[] {
-    return [...this.extensionService.extensionSettings.values()].flatMap(({ optimizationPolicies }) => optimizationPolicies ?? []);
-  }
-
   get hasChangesToUpload() {
     return Object.keys(this.changesToUpload()).length > 0;
+  }
+
+  getOptimizationPolicies(extensionId: string): string[] {
+    return this.extensionService.extensionSettings.get(extensionId)?.optimizationPolicies ?? [];
   }
 
   async executeModel(modelItem: ModelItem) {

--- a/src/ui/src/services/model_loader_service.ts
+++ b/src/ui/src/services/model_loader_service.ts
@@ -98,6 +98,9 @@ export class ModelLoaderService implements ModelLoaderServiceInterface {
       result = await this.sendExecuteRequest(
         modelItem,
         updatedPath,
+        {
+          optimizationPolicy: this.selectedOptimizationPolicy()
+        }
       );
     }
     // Upload or graph jsons from server.
@@ -123,6 +126,9 @@ export class ModelLoaderService implements ModelLoaderServiceInterface {
       result = await this.sendExecuteRequest(
         modelItem,
         updatedPath,
+        {
+          optimizationPolicy: this.selectedOptimizationPolicy()
+        }
       );
     }
 
@@ -410,7 +416,8 @@ export class ModelLoaderService implements ModelLoaderServiceInterface {
 
   private async sendExecuteRequest(
     modelItem: ModelItem,
-    path: string
+    path: string,
+    settings: Record<string, any> = {}
   ) {
     let result: ExecutionCommand | undefined = undefined;
 
@@ -420,7 +427,7 @@ export class ModelLoaderService implements ModelLoaderServiceInterface {
       cmdId: 'execute',
       extensionId: modelItem.selectedAdapter?.id ?? '',
       modelPath: path,
-      settings: {},
+      settings,
       deleteAfterConversion: false
     }
 

--- a/src/ui/src/services/model_loader_service.ts
+++ b/src/ui/src/services/model_loader_service.ts
@@ -75,6 +75,9 @@ export class ModelLoaderService implements ModelLoaderServiceInterface {
 
   readonly graphErrors = signal<string[] | undefined>(undefined);
 
+  readonly optimizationPolicies = signal<string[]>([]);
+  readonly selectedOptimizationPolicy = signal<string>('');
+
   constructor(
     private readonly settingsService: SettingsService,
     readonly extensionService: ExtensionService,


### PR DESCRIPTION
To show optimization policies, the backend has to send, along with the graphs for the `get_extensions` command the `settings` property, containing the `optimizationPolicies` list.

Like this:
```jsonc
[
  {
    "id": "tt_adapter",
    "name": "Tenstorrent Adapter",
    "description": "Prototype adapter from TT BUDA to Model Explorer",
    "source_repo": "https://github.com/vprajapati-tt/tt-explorer",
    "fileExts": [
      "ttir",
      "mlir"
    ],
    "type": "adapter",
    "settings": {
      "optimizationPolicies": ["a", "b", "c"]
    }
  }
]
```

Then the UI will list that close to the execute button along with a dropdown with the existing execution policies.

<img width="233" alt="image" src="https://github.com/user-attachments/assets/b88146d8-b483-42e8-93d5-c767cedf4eb3">

The selected policy will be sent with the `execute` command, on the `settings` property with the name `executionPolicy`.

Like this:
```jsonc
{
    "cmdId": "execute",
    "extensionId": "tt_adapter",
    "modelPath": "/var/folders/zy/_y6qtvgx19sfz9s1509g6mp40000gp/T/tmptpmouo6a/test_layout.ttir",
    "settings": {
        "optimizationPolicy": "Foo"
    },
    "deleteAfterConversion": false
}
```

This resolves #4 