### PR TITLE
Fix: nightly build verification check

### DIFF
--- a/src/builtin-adapter/python/pip_package/MANIFEST.in
+++ b/src/builtin-adapter/python/pip_package/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include * *.py
+recursive-include ai_edge_model_explorer_adapter *.py

--- a/src/builtin-adapter/python/pip_package/build_pip_package.sh
+++ b/src/builtin-adapter/python/pip_package/build_pip_package.sh
@@ -114,10 +114,10 @@ elif test -e "/etc/lsb-release"; then
 fi
 
 if [[ -n "${WHEEL_PLATFORM_NAME}" ]]; then
-  ${PYTHON} setup.py bdist --plat-name=${WHEEL_PLATFORM_NAME} \
+  ${PYTHON} setup.py sdist \
                       bdist_wheel --plat-name=${WHEEL_PLATFORM_NAME}
 else
-  ${PYTHON} setup.py bdist bdist_wheel
+  ${PYTHON} setup.py sdist bdist_wheel
 fi
 
 echo "Output can be found here:"

--- a/src/builtin-adapter/python/pip_package/setup_with_binary.py
+++ b/src/builtin-adapter/python/pip_package/setup_with_binary.py
@@ -63,8 +63,8 @@ setup(
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    packages=find_packages(exclude=[]),
-    package_dir={'': '.'},
-    package_data={'': ['*.so', '*.pyd']},
+    packages=['ai_edge_model_explorer_adapter'],
+    package_dir={'ai_edge_model_explorer_adapter': 'ai_edge_model_explorer_adapter'},
+    package_data={'ai_edge_model_explorer_adapter': ['*.so', '*.pyd']},
     install_requires=[],
 )


### PR DESCRIPTION
## Summary

Resolves issues with the package check step for the python wheel build.

Before it was generating the wrong file structure, thus failing package verification. Now it is generating the correct file type and passing verification.