### PR TITLE
Feature: add description for optimizer policies

### DIFF
--- a/src/ui/src/components/execution_settings_dialog/execution_settings_dialog.ng.html
+++ b/src/ui/src/components/execution_settings_dialog/execution_settings_dialog.ng.html
@@ -53,7 +53,9 @@ limitations under the License.
 
         <dl>
           <dt>Optimizer disabled</dt>
-          <dd>This policy will disable any optimizations and ignore overrides.</dd>
+          <dd>Disables any optimizations and ignore overrides.</dd>
+          <dt>DFShardingPolicy</dt>
+          <dd>Improve model performance by optimizing tensor memory layouts to maximize the usage of fast, L1 memory instead of DRAM.</dd>
         </dl>
       </details>
     }

--- a/src/ui/src/components/execution_settings_dialog/execution_settings_dialog.ng.html
+++ b/src/ui/src/components/execution_settings_dialog/execution_settings_dialog.ng.html
@@ -54,6 +54,7 @@ limitations under the License.
         <dl>
           <dt>Optimizer disabled</dt>
           <dd>Disables any optimizations and ignore overrides.</dd>
+
           <dt>DFShardingPolicy</dt>
           <dd>Improve model performance by optimizing tensor memory layouts to maximize the usage of fast, L1 memory instead of DRAM.</dd>
         </dl>

--- a/src/ui/src/components/execution_settings_dialog/execution_settings_dialog.ng.html
+++ b/src/ui/src/components/execution_settings_dialog/execution_settings_dialog.ng.html
@@ -45,6 +45,17 @@ limitations under the License.
           }
         </select>
       </div>
+      <details>
+        <summary>Optimization Policies Description</summary>
+
+        <p>Below is a list of the optimization policies and what changes they do.</p>
+        <p>Please note not all optimization policies may be available at the time.</p>
+
+        <dl>
+          <dt>Optimizer disabled</dt>
+          <dd>This policy will disable any optimizations and ignore overrides.</dd>
+        </dl>
+      </details>
     }
 
     <div class="setting-item">


### PR DESCRIPTION
## Summary

Add a description for optimization policies below the policy selector to help users with documentation of the policies.

Resolves #38 